### PR TITLE
Fix: Passing `rende_mode` on in case `generate_room` raises an exception

### DIFF
--- a/gym_sokoban/envs/sokoban_env.py
+++ b/gym_sokoban/envs/sokoban_env.py
@@ -209,7 +209,7 @@ class SokobanEnv(gym.Env):
         except (RuntimeError, RuntimeWarning) as e:
             print("[SOKOBAN] Runtime Error/Warning: {}".format(e))
             print("[SOKOBAN] Retry . . .")
-            return self.reset(second_player=second_player)
+            return self.reset(second_player=second_player, render_mode=render_mode)
 
         self.player_position = np.argwhere(self.room_state == 5)[0]
         self.num_env_steps = 0


### PR DESCRIPTION
I'm using the `tiny_*` version in my experiments because they are much faster. 
To do so, I've written a gym wrapper, that just passes `tiny_rgb_array` to both `step()` and `reset`.
However, the program fails if the `generate_room()` call raises an Exception, because in that case, the `render_mode` is not correctly passed on to the new `reset()` call.

This PR just adds the additional argument.