### PR TITLE
Supporting kwargs in env variants

### DIFF
--- a/gym_sokoban/envs/sokoban_env_variations.py
+++ b/gym_sokoban/envs/sokoban_env_variations.py
@@ -10,10 +10,12 @@ class SokobanEnv1(SokobanEnv):
         'render.modes': ['human', 'rgb_array', 'tiny_human', 'tiny_rgb_array'],
     }
 
-    def __init__(self):
-        super(SokobanEnv1, self).__init__(
-            num_boxes=3, max_steps=200
-        )
+    def __init__(self, **kwargs):
+        num_boxes = kwargs.get('num_boxes', 3)
+        max_steps = kwargs.get('max_steps', 200)
+        kwargs['num_boxes'] = num_boxes
+        kwargs['max_steps'] = max_steps
+        super(SokobanEnv1, self).__init__(**kwargs)
 
 
 class SokobanEnv2(SokobanEnv):


### PR DESCRIPTION
Note that the following code doesn't compile:
```
env = gym.make('Sokoban-v0', max_steps=400)
```
Because https://github.com/mpSchrader/gym-sokoban/blob/master/gym_sokoban/envs/sokoban_env_variations.py#L8 does not support kwargs. This PR is fixing this issue for this specific env only. Suggested to patch all other env classes.