### PR TITLE
Environment Variable for Sokoban Cache Path

### DIFF
--- a/docs/variations/Boxoban.md
+++ b/docs/variations/Boxoban.md
@@ -6,7 +6,7 @@
 
 
 ## 1. Idea
-Instead of generating a new level on every reset operation, a pregenerated level is choosen randomly. When Boxoban is run for the first time the levels are downloaded from DeepMinds [Github repository](https://github.com/deepmind/boxoban-levels) and stored in the folder _.sokoban_cache_. 
+Instead of generating a new level on every reset operation, a pregenerated level is choosen randomly. When Boxoban is run for the first time the levels are downloaded from DeepMinds [Github repository](https://github.com/deepmind/boxoban-levels) and stored in the folder _.sokoban_cache_. This path can be changed by environment variable `SOKOBAN_CACHE_PATH`
 
 In case you use the Boxoban levels for your research, the authors of the boxoban-levels repository ask you to cite their work as follows:
 ```

--- a/docs/variations/Boxoban.md
+++ b/docs/variations/Boxoban.md
@@ -6,7 +6,7 @@
 
 
 ## 1. Idea
-Instead of generating a new level on every reset operation, a pregenerated level is choosen randomly. When Boxoban is run for the first time the levels are downloaded from DeepMinds [Github repository](https://github.com/deepmind/boxoban-levels) and stored in the folder _.sokoban_cache_. This path can be changed by environment variable `SOKOBAN_CACHE_PATH`
+Instead of generating a new level on every reset operation, a pre-generated level is chosen randomly. When Boxoban is run for the first time the levels are downloaded from DeepMinds [Github repository](https://github.com/deepmind/boxoban-levels) and stored in the folder _.sokoban_cache_. This path can be changed by environment variable `SOKOBAN_CACHE_PATH`
 
 In case you use the Boxoban levels for your research, the authors of the boxoban-levels repository ask you to cite their work as follows:
 ```
@@ -17,7 +17,7 @@ howpublished= {https://github.com/deepmind/boxoban-levels/},
 year = "2018",
 }
 ```
-Dedending on your use case, please consider the [licence](https://github.com/deepmind/boxoban-levels/blob/master/LICENSE) of DeepMinds repository.
+Depending on your use case, please consider the [licence](https://github.com/deepmind/boxoban-levels/blob/master/LICENSE) of DeepMinds repository.
 
 ## 2. Rules
 Same rules as the regular Sokoban game.

--- a/gym_sokoban/envs/boxoban_env.py
+++ b/gym_sokoban/envs/boxoban_env.py
@@ -23,7 +23,7 @@ class BoxobanEnv(SokobanEnv):
         
 
     def reset(self):
-        self.cache_path = '.sokoban_cache'
+        self.cache_path = os.environ.get('SOKOBAN_CACHE_PATH', default='.sokoban_cache')
         self.train_data_dir = os.path.join(self.cache_path, 'boxoban-levels-master', self.difficulty, self.split)
 
         if not os.path.exists(self.cache_path):


### PR DESCRIPTION
The default download path for boxbon environments is `.sokoban_cache`. To provide flexibility, I have introduced an environment variable called `SOKOBAN_CACHE_PATH` that allows users to customize the default path. If the `SOKOBAN_CACHE_PATH` variable is not set, the reset method will use the default path.